### PR TITLE
OpenCTI: EnvFromSecret variable not taking precedence over normal env in chart

### DIFF
--- a/charts/opencti/templates/connector/deployment.yaml
+++ b/charts/opencti/templates/connector/deployment.yaml
@@ -54,35 +54,9 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .image.pullPolicy | default "IfNotPresent" }}
           env:
-          # Variables in plain text
-          {{- if eq $.Values.env.APP__BASE_PATH "/" }}
-          - name: OPENCTI_URL
-            value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}"
-          {{- else }}
-          - name: OPENCTI_URL
-            value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}{{ $.Values.env.APP__BASE_PATH }}"
-          {{- end }}
+          # Variables from secrets have precedence
+          {{- $envList := dict -}}
 
-          {{- if $.Values.env.APP__ADMIN__TOKEN }}
-          - name: OPENCTI_TOKEN
-            value: "{{ $.Values.env.APP__ADMIN__TOKEN }}"
-          {{- end }}
-
-          {{- if $.Values.connectorsGlobalEnv }}
-          {{- range $key, $value := $.Values.connectorsGlobalEnv }}
-          - name: {{ $key | upper }}
-            value: {{ $value | quote }}
-          {{- end }}
-          {{- end }}
-
-          {{- if .env }}
-          {{- range $key, $value := .env }}
-          - name: {{ $key | upper }}
-            value: {{ $value | quote }}
-          {{- end }}
-          {{- end }}
-
-          # Variables from secrets
           {{- if .envFromSecrets }}
           {{- range $key, $value := .envFromSecrets }}
           - name: {{ $key | upper }}
@@ -90,8 +64,37 @@ spec:
               secretKeyRef:
                 name: {{ $value.name }}
                 key: {{ $value.key | default $key }}
+          {{- $_ := set $envList $key true }}
           {{- end }}
           {{- end }}
+
+          {{- if and (not (hasKey $envList "OPENCTI_TOKEN")) (.env.APP__ADMIN__TOKEN) }}
+          - name: OPENCTI_TOKEN
+            value: "{{ .env.APP__ADMIN__TOKEN }}"
+          {{- end }}
+
+          # Special handling for OPENCTI_URL which is constructed from other values
+          {{- if not (hasKey $.Values.env "OPENCTI_URL") }}
+          {{- if eq $.Values.env.APP__BASE_PATH "/" }}
+          - name: OPENCTI_URL
+            value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}"
+          {{- else }}
+          - name: OPENCTI_URL
+            value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}{{ $.Values.env.APP__BASE_PATH }}"
+          {{- end }}
+          {{- end }}
+
+          # Add Variables in plain text if they were not already added from secrets
+          {{- if .env }}
+          {{- range $key, $value := .env }}
+          {{- if not (hasKey $envList $key) }}
+          - name: {{ $key | upper }}
+            value: {{ $value | quote }}
+          {{- $_ := set $envList $key true }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          
           resources:
             {{- toYaml .resources | nindent 12 }}
       {{- with .nodeSelector }}

--- a/charts/opencti/templates/server/deployment.yaml
+++ b/charts/opencti/templates/server/deployment.yaml
@@ -123,34 +123,32 @@ spec:
           - name: PROVIDERS__LOCAL__STRATEGY
             value: LocalStrategy
 
-          # Variables in plain text
+          # Variables from secrets have precedence
+          {{- $envList := dict -}}
+          {{- if .Values.envFromSecrets }}
+          {{- range $key, $value := .Values.envFromSecrets }}
+          {{- if not (hasKey $envList $key) }}
+          - name: {{ $key | upper }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $value.name }}
+                key: {{ $value.key | default $key }}
+          {{- $_ := set $envList $key true }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
+          # Add Variables in plain text if they were not already added from secrets
           {{- if .Values.env }}
           {{- range $key, $value := .Values.env }}
+          {{- if not (hasKey $envList $key) }}
           - name: {{ $key | upper }}
             value: {{ $value | quote }}
+          {{- $_ := set $envList $key true }}
           {{- end }}
-          {{- end }}
-
-          # Variables from secrets
-          {{- if .Values.envFromSecrets }}
-          {{- range $key, $value := .Values.envFromSecrets }}
-          - name: {{ $key | upper }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $value.name }}
-                key: {{ $value.key | default $key }}
           {{- end }}
           {{- end }}
 
-          {{- if .Values.envFromSecrets }}
-          {{- range $key, $value := .Values.envFromSecrets }}
-          - name: {{ $key | upper }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $value.name }}
-                key: {{ $value.key | default $key }}
-          {{- end }}
-          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/opencti/templates/worker/deployment.yaml
+++ b/charts/opencti/templates/worker/deployment.yaml
@@ -64,26 +64,10 @@ spec:
               protocol: TCP
             {{- end }}
           env:
-          # Variables in plain text
-          {{- if eq .Values.env.APP__BASE_PATH "/" }}
-          - name: OPENCTI_URL
-            value: "http://{{ include "opencti.fullname" . }}-server:{{ .Values.service.port }}"
-          {{- else }}
-          - name: OPENCTI_URL
-            value: "http://{{ include "opencti.fullname" . }}-server:{{ .Values.service.port }}{{ .Values.env.APP__BASE_PATH }}"
-          {{- end }}
-          {{- if .Values.env.APP__ADMIN__TOKEN }}
-          - name: OPENCTI_TOKEN
-            value: "{{ .Values.env.APP__ADMIN__TOKEN }}"
-          {{- end }}
-          {{- if .Values.worker.env }}
-          {{- range $key, $value := .Values.worker.env }}
-          - name: {{ $key | upper }}
-            value: {{ $value | quote }}
-          {{- end }}
-          {{- end }}
+          # Variables from secrets have precedence
 
-          # Variables from secrets
+          {{- $envList := dict -}}
+
           {{- if .Values.worker.envFromSecrets }}
           {{- range $key, $value := .Values.worker.envFromSecrets }}
           - name: {{ $key | upper }}
@@ -91,8 +75,37 @@ spec:
               secretKeyRef:
                 name: {{ $value.name }}
                 key: {{ $value.key | default $key }}
+          {{- $_ := set $envList $key true }}
           {{- end }}
           {{- end }}
+
+          # Special handling for OPENCTI_URL which is constructed from other values
+          {{- if not (hasKey $envList "OPENCTI_URL") }}
+          {{- if eq .Values.env.APP__BASE_PATH "/" }}
+          - name: OPENCTI_URL
+            value: "http://{{ include "opencti.fullname" . }}-server:{{ .Values.service.port }}"
+          {{- else }}
+          - name: OPENCTI_URL
+            value: "http://{{ include "opencti.fullname" . }}-server:{{ .Values.service.port }}{{ .Values.env.APP__BASE_PATH }}"
+          {{- end }}
+          {{- end }}
+
+          {{- if and (not (hasKey $envList "OPENCTI_TOKEN")) (.Values.env.APP__ADMIN__TOKEN) }}
+          - name: OPENCTI_TOKEN
+            value: "{{ .Values.env.APP__ADMIN__TOKEN }}"
+          {{- end }}
+
+          # Add Variables in plain text from .Values.worker.env if they were not already added from secrets
+          {{- if .Values.worker.env }}
+          {{- range $key, $value := .Values.worker.env }}
+          {{- if not (hasKey $envList $key) }}
+          - name: {{ $key | upper }}
+            value: {{ $value | quote }}
+          {{- $_ := set $envList $key true }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       {{- with .Values.worker.nodeSelector }}


### PR DESCRIPTION
## Current Behaviour 

I am using the `OpenCTI` chart to install a connector and I am having some issues when setting env vars from secrets.

I am customising the deployment of the chart with the following `values.yaml`:

```yaml
connectors:
  - name: connector-import-file-stix
    enabled: true
    image:
      repository: opencti/connector-import-file-stix
    env:
      CONNECTOR_ID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
      CONNECTOR_TYPE: INTERNAL_IMPORT_FILE
      CONNECTOR_NAME: ImportFileStix
      CONNECTOR_VALIDATE_BEFORE_IMPORT: "true"
      CONNECTOR_SCOPE: application/json,text/xml
      CONNECTOR_AUTO: "true"
      CONNECTOR_CONFIDENCE_LEVEL: 15
      CONNECTOR_LOG_LEVEL: info
    envFromSecrets:
      OPENCTI_TOKEN:
        name: admin-credentials
        key: api-token
```

But when I generate the configuration using the chart, I get the following results

```yaml
containers:
        - name: connector-import-file-stix-connector
          securityContext:
            null
          image: "opencti/connector-import-file-stix:6.0.5"
          imagePullPolicy: IfNotPresent
          env:
          # Variables in plain text
          - name: OPENCTI_URL
            value: "http://cti-opencti-server:80"
          - name: OPENCTI_TOKEN
            value: "ChangeMe"
          - name: CONNECTOR_AUTO
            value: "true"
          - name: CONNECTOR_CONFIDENCE_LEVEL
            value: "15"
          - name: CONNECTOR_ID
            value: "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
          - name: CONNECTOR_LOG_LEVEL
            value: "info"
          - name: CONNECTOR_NAME
            value: "ImportFileStix"
          - name: CONNECTOR_SCOPE
            value: "application/json,text/xml"
          - name: CONNECTOR_TYPE
            value: "INTERNAL_IMPORT_FILE"
          - name: CONNECTOR_VALIDATE_BEFORE_IMPORT
            value: "true"

          # Variables from secrets
          - name: OPENCTI_TOKEN
            valueFrom:
              secretKeyRef:
                name: admin-credentials
                key: api-token
          resources:
            null
```

Notice how `OPENCTI_TOKEN` is duplicated in the env variables and once it is deployed, it ignores the variable configured from the secret. It is configuring the default value and also the custom value.

**Note:** This also happens for the `server` and `worker` deployments.

## Expected Behaviour

Environmental variables shouldn't be duplicated and if they are duplicated, the ones from the secrets should take precedence.