### PR TITLE
fix(opencti): serviceaccount indent

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     url: https://ialejandro.rocks
 sources:
   - https://github.com/OpenCTI-Platform/opencti
-version: 1.2.1
+version: 1.2.2
 appVersion: "6.0.5"
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:

--- a/charts/opencti/templates/serviceaccount.yaml
+++ b/charts/opencti/templates/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default "false" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default "false" }}
 {{- end }}


### PR DESCRIPTION
fixed serviceaccount `automountServiceAccountToken` indent

ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting>